### PR TITLE
Make EmbedWorkflow::Client thread-safe

### DIFF
--- a/lib/embed_workflow/client.rb
+++ b/lib/embed_workflow/client.rb
@@ -7,11 +7,9 @@ module EmbedWorkflow
     BASE_API_URL  = "https://embedworkflow.com/".freeze
 
     def client
-      return @client if defined?(@client)
-      @client         = create_connection(URI.parse(BASE_API_URL))
-      @client.use_ssl = true
-
-      @client
+      create_connection(URI.parse(BASE_API_URL)).tap do |client|
+        client.use_ssl = true
+      end
     end
 
     def get_request(path:, auth: true, params: {})


### PR DESCRIPTION
Before this commit, enqueuing multiple Sidekiq that would call `EmbedWorkflow.trigger` resulted in a lot of errors. Here is a picture of what happens when enqueuing 100 jobs simultaneously that call `EmbedWorkflow.trigger`. There are a lot of errors such as: 

- IOError: stream closed in another thread
- FrozenError: can't modify frozen OpenSSL::SSL::SSLContext

<img width="1600" height="561" alt="image" src="https://github.com/user-attachments/assets/5b5ae47d-0074-4b13-93a4-d614909dfbaa" />

This is because `Net::HTTP` isn't thread-safe so we can't reuse the `@client` variable across threads like this. The simplest way to fix the issue is for `#client` to return a new `Net::HTTP` instance every time.