### PR TITLE
Add time_zone support for user upsert

### DIFF
--- a/lib/embed_workflow/base.rb
+++ b/lib/embed_workflow/base.rb
@@ -2,10 +2,18 @@
 
 module EmbedWorkflow
   module Base
+    UNSET = Object.new.freeze
+
     attr_accessor :skey
 
     class << self
       attr_accessor :skey
     end
+
+    private
+
+      def prepare_params(hash)
+        hash.reject { |_, v| v == UNSET }
+      end
   end
 end

--- a/lib/embed_workflow/users.rb
+++ b/lib/embed_workflow/users.rb
@@ -11,14 +11,15 @@ module EmbedWorkflow
 
       RESOURCE_BASE_PATH = "#{BASE_API_PATH}/users".freeze
 
-      def upsert(key:, name: nil, email: nil, data: nil, groups: nil)
-        attrs = {
+      def upsert(key:, name: UNSET, email: UNSET, data: UNSET, groups: UNSET, time_zone: UNSET)
+        attrs = prepare_params({
           key: key,
           name: name,
           email: email,
           data: data,
-          groups: groups
-        }.compact
+          groups: groups,
+          time_zone: time_zone
+        })
 
         put_request(
           path: "#{RESOURCE_BASE_PATH}/#{key}",

--- a/spec/users_spec.rb
+++ b/spec/users_spec.rb
@@ -91,6 +91,8 @@ describe "users" do
               key: "api-user-1",
               name: "Jane Doe",
               email: "jane@example.com",
+              time_zone: "America/New_York",
+              groups: ["admin", "users"],
               data: data
             }
           })
@@ -103,7 +105,59 @@ describe "users" do
           key: "api-user-1",
           name: "Jane Doe",
           email: "jane@example.com",
+          time_zone: "America/New_York",
+          groups: ["admin", "users"],
           data: data
+        )
+      end
+    end
+
+    context "with nil values to unset fields" do
+      before do
+        allow_any_instance_of(EmbedWorkflow::Client)
+          .to receive(:put_request)
+          .with({
+            path: "/api/v1/users/api-user-1",
+            body: {
+              key: "api-user-1",
+              time_zone: nil,
+              groups: nil
+            }
+          })
+          .and_return("response")
+      end
+
+      it "sends nil values to unset time_zone and groups" do
+        EmbedWorkflow::Users.upsert(
+          key: "api-user-1",
+          time_zone: nil,
+          groups: nil
+        )
+      end
+    end
+
+    context "with mixed nil and provided values" do
+      before do
+        allow_any_instance_of(EmbedWorkflow::Client)
+          .to receive(:put_request)
+          .with({
+            path: "/api/v1/users/api-user-1",
+            body: {
+              key: "api-user-1",
+              name: "Jane Doe",
+              email: "jane@example.com",
+              groups: nil
+            }
+          })
+          .and_return("response")
+      end
+
+      it "sends both set and unset values correctly" do
+        EmbedWorkflow::Users.upsert(
+          key: "api-user-1",
+          name: "Jane Doe",
+          email: "jane@example.com",
+          groups: nil
         )
       end
     end


### PR DESCRIPTION
This PR adds time_zone parameter to the Users.upsert method, allowing you to set user time zones for better scheduling and localization.

Changes

  - Added time_zone parameter to Users.upsert
  - Introduced UNSET sentinel value to support clearing optional fields
  - Added prepare_params helper to properly handle nil vs omitted parameters

Usage

```ruby
# Set time zone
EmbedWorkflow::Users.upsert(key: "user-123", time_zone: "America/New_York")

# Clear time zone
EmbedWorkflow::Users.upsert(key: "user-123", time_zone: nil)
```

API documentation: https://docs.embedworkflow.com/reference/users/upsert-user
